### PR TITLE
Updated ignore for non-template config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__/
 *.egg-info/
 build/
+
+awe_languagetool/LanguageTool5_5/*.cfg


### PR DESCRIPTION
Since we decided to not put the config file directly into the LanguageTool5_5 directory - instead we place a copy in the main repo directory - we need to ignore user-placed config files.